### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
         "jquery.counterup": "^2.1.0",
         "scrollreveal": "^3.4.0",
         "slick-carousel": "^1.8.1",
-        "wallop": "^2.4.1"
+        "wallop": "^2.4.1",
+        "graceful-fs":  "4.2.2"
     }
 }
+


### PR DESCRIPTION
Because everything in the JS ecosystem is a fustercluck

https://stackoverflow.com/a/58394828/10572218

_This issue stems from the fact that gulp@3.9.1 depends on graceful-fs@^3.0.0 which monkeypatches Node.js fs module.

This used to work with Node.js until version 11.15 (which is a version from a development branch and shouldn't be used in production).

graceful-fs@^4.0.0 does not monkeypatch Node.js fs module anymore, which makes it compatible with Node.js > 11.15 (tested and working with versions 12 and 14).

Note that this is not a perennial solution but it helps when you don't have the time to update to gulp@^4.0.0._